### PR TITLE
rename module name

### DIFF
--- a/lua/koralle/plugins/ddc/init.lua
+++ b/lua/koralle/plugins/ddc/init.lua
@@ -25,7 +25,7 @@ local spec = {
         ui = "pum",
         sources = {
           "copilot",
-          "nvim-lsp",
+          "lsp",
           "file",
           "around",
           "mocword",
@@ -55,7 +55,7 @@ local spec = {
             isVolatile = true,
             maxItems = 20,
           },
-          ["nvim-lsp"] = {
+          lsp = {
             mark = "🦍[LSP]",
             dup = "keep",
             keywordPattern = "\\k+",
@@ -69,7 +69,7 @@ local spec = {
           },
         },
         sourceParams = {
-          ["nvim-lsp"] = {
+          lsp = {
             snippetEngine = vim.fn["denops#callback#register"](function(body)
               vim.fn["vsnip#anonymous"](body)
             end),

--- a/lua/koralle/plugins/lsp/deno-ls.lua
+++ b/lua/koralle/plugins/lsp/deno-ls.lua
@@ -1,4 +1,4 @@
-require("ddc_nvim_lsp_setup").setup()
+require("ddc_source_lsp_setup").setup()
 
 vim.g.markdown_fenced_languages = {
   "ts=typescript",

--- a/lua/koralle/plugins/lsp/emmet_ls.lua
+++ b/lua/koralle/plugins/lsp/emmet_ls.lua
@@ -1,4 +1,4 @@
-require("ddc_nvim_lsp_setup").setup()
+require("ddc_source_lsp_setup").setup()
 
 require("lspconfig").emmet_language_server.setup({
   filetypes = { "html", "css", "javascript", "javascriptreact", "typescript", "typescriptreact" },

--- a/lua/koralle/plugins/lsp/html.lua
+++ b/lua/koralle/plugins/lsp/html.lua
@@ -1,3 +1,3 @@
-require("ddc_nvim_lsp_setup").setup()
+require("ddc_source_lsp_setup").setup()
 
 require("lspconfig").html.setup({})

--- a/lua/koralle/plugins/lsp/lua-ls.lua
+++ b/lua/koralle/plugins/lsp/lua-ls.lua
@@ -1,4 +1,4 @@
-require("ddc_nvim_lsp_setup").setup()
+require("ddc_source_lsp_setup").setup()
 
 require("lspconfig").lua_ls.setup({
   on_init = function(client)

--- a/lua/koralle/plugins/lsp/marksman.lua
+++ b/lua/koralle/plugins/lsp/marksman.lua
@@ -1,4 +1,4 @@
-require("ddc_nvim_lsp_setup").setup()
+require("ddc_source_lsp_setup").setup()
 
 local lspconfig = require("lspconfig")
 

--- a/lua/koralle/plugins/lsp/rust-analyzer.lua
+++ b/lua/koralle/plugins/lsp/rust-analyzer.lua
@@ -1,4 +1,4 @@
-require("ddc_nvim_lsp_setup").setup()
+require("ddc_source_lsp_setup").setup()
 
 require("lspconfig").rust_analyzer.setup({
   settings = {

--- a/lua/koralle/plugins/lsp/tsserver.lua
+++ b/lua/koralle/plugins/lsp/tsserver.lua
@@ -1,4 +1,4 @@
-require("ddc_nvim_lsp_setup").setup()
+require("ddc_source_lsp_setup").setup()
 
 local lspconfig = require("lspconfig")
 lspconfig.tsserver.setup({


### PR DESCRIPTION
- rename(ddc): source name `nvim-lsp` to `lsp`
- fix
